### PR TITLE
Add tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,6 +81,14 @@ For example, to enable the MCP server in your workspace, create a `.vscode/mcp.j
     uv run python -m mong_mcp_server
     ```
 
+## Running Tests
+
+Run the unit tests to verify the server functionality:
+
+```sh
+uv run python -m unittest discover tests/
+```
+
 ## License
 
 This project is licensed under the MIT License. See the [LICENSE](LICENSE) file for details.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,6 +10,7 @@ dependencies = [
     "mong>=0.0.3",
 ]
 
+
 [build-system]
 requires = ["hatchling"]
 build-backend = "hatchling.build"

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -11,8 +11,7 @@ class TestMongMCPServer(unittest.TestCase):
         mock_mcp_instance = MagicMock()
         mock_fastmcp.return_value = mock_mcp_instance
 
-        with patch('mong_mcp_server.server.FastMCP.run'):
-            main()
+        main()
 
         mock_fastmcp.assert_called_once_with(
             "mong-mcp-server",
@@ -25,13 +24,12 @@ class TestMongMCPServer(unittest.TestCase):
         mock_mcp_instance = MagicMock()
         mock_fastmcp.return_value = mock_mcp_instance
 
-        with patch('mong_mcp_server.server.FastMCP.run'):
-            main()
+        main()
 
-        mock_mcp_instance.tool.assert_called_once()
-        call_args = mock_mcp_instance.tool.call_args
-        self.assertEqual(call_args[1]['name'], 'get_random_name')
-        self.assertEqual(call_args[1]['description'], 'Generate a random name like Docker does.')
+        mock_mcp_instance.tool.assert_called_once_with(
+            name='get_random_name',
+            description='Generate a random name like Docker does.'
+        )
 
     @patch('mong_mcp_server.server.FastMCP')
     def test_server_run_called(self, mock_fastmcp):

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -1,0 +1,83 @@
+import unittest
+from unittest.mock import patch, MagicMock
+from mong_mcp_server.server import main
+import mong
+
+
+class TestMongMCPServer(unittest.TestCase):
+
+    def test_get_random_name_returns_string(self):
+        """Test that get_random_name returns a string"""
+        with patch('mong.get_random_name') as mock_get_name:
+            mock_get_name.return_value = "test_name"
+            result = mong.get_random_name()
+            self.assertIsInstance(result, str)
+            self.assertEqual(result, "test_name")
+
+    def test_get_random_name_called(self):
+        """Test that mong.get_random_name is called"""
+        with patch('mong.get_random_name') as mock_get_name:
+            mock_get_name.return_value = "brave_newton"
+            result = mong.get_random_name()
+            mock_get_name.assert_called_once()
+            self.assertEqual(result, "brave_newton")
+
+    @patch('mong_mcp_server.server.FastMCP')
+    def test_server_initialization(self, mock_fastmcp):
+        """Test that the server initializes correctly"""
+        mock_mcp_instance = MagicMock()
+        mock_fastmcp.return_value = mock_mcp_instance
+
+        with patch('mong_mcp_server.server.FastMCP.run'):
+            main()
+
+        mock_fastmcp.assert_called_once_with(
+            "mong-mcp-server",
+            "MCP server to generate Docker-like random names"
+        )
+
+    @patch('mong_mcp_server.server.FastMCP')
+    def test_tool_registration(self, mock_fastmcp):
+        """Test that the get_random_name tool is registered"""
+        mock_mcp_instance = MagicMock()
+        mock_fastmcp.return_value = mock_mcp_instance
+
+        with patch('mong_mcp_server.server.FastMCP.run'):
+            main()
+
+        mock_mcp_instance.tool.assert_called_once()
+        call_args = mock_mcp_instance.tool.call_args
+        self.assertEqual(call_args[1]['name'], 'get_random_name')
+        self.assertEqual(call_args[1]['description'], 'Generate a random name like Docker does.')
+
+    @patch('mong_mcp_server.server.FastMCP')
+    def test_server_run_called(self, mock_fastmcp):
+        """Test that the server run method is called"""
+        mock_mcp_instance = MagicMock()
+        mock_fastmcp.return_value = mock_mcp_instance
+
+        main()
+
+        mock_mcp_instance.run.assert_called_once()
+
+
+class TestIntegration(unittest.TestCase):
+
+    def test_mong_library_integration(self):
+        """Test integration with the mong library"""
+        result = mong.get_random_name()
+        self.assertIsInstance(result, str)
+        self.assertGreater(len(result), 0)
+        self.assertTrue('_' in result or '-' in result)
+
+    def test_multiple_names_are_different(self):
+        """Test that multiple calls return different names (probabilistically)"""
+        names = set()
+        for _ in range(10):
+            names.add(mong.get_random_name())
+
+        self.assertGreater(len(names), 1)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -1,26 +1,9 @@
 import unittest
 from unittest.mock import patch, MagicMock
 from mong_mcp_server.server import main
-import mong
 
 
 class TestMongMCPServer(unittest.TestCase):
-
-    def test_get_random_name_returns_string(self):
-        """Test that get_random_name returns a string"""
-        with patch('mong.get_random_name') as mock_get_name:
-            mock_get_name.return_value = "test_name"
-            result = mong.get_random_name()
-            self.assertIsInstance(result, str)
-            self.assertEqual(result, "test_name")
-
-    def test_get_random_name_called(self):
-        """Test that mong.get_random_name is called"""
-        with patch('mong.get_random_name') as mock_get_name:
-            mock_get_name.return_value = "brave_newton"
-            result = mong.get_random_name()
-            mock_get_name.assert_called_once()
-            self.assertEqual(result, "brave_newton")
 
     @patch('mong_mcp_server.server.FastMCP')
     def test_server_initialization(self, mock_fastmcp):
@@ -59,24 +42,6 @@ class TestMongMCPServer(unittest.TestCase):
         main()
 
         mock_mcp_instance.run.assert_called_once()
-
-
-class TestIntegration(unittest.TestCase):
-
-    def test_mong_library_integration(self):
-        """Test integration with the mong library"""
-        result = mong.get_random_name()
-        self.assertIsInstance(result, str)
-        self.assertGreater(len(result), 0)
-        self.assertTrue('_' in result or '-' in result)
-
-    def test_multiple_names_are_different(self):
-        """Test that multiple calls return different names (probabilistically)"""
-        names = set()
-        for _ in range(10):
-            names.add(mong.get_random_name())
-
-        self.assertGreater(len(names), 1)
 
 
 if __name__ == '__main__':

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -37,7 +37,8 @@ class TestMongMCPServer(unittest.TestCase):
         mock_mcp_instance = MagicMock()
         mock_fastmcp.return_value = mock_mcp_instance
 
-        main()
+        with patch('mong_mcp_server.server.FastMCP.run'):
+            main()
 
         mock_mcp_instance.run.assert_called_once()
 


### PR DESCRIPTION
This pull request introduces unit tests for the MCP server, updates documentation to include instructions for running tests, and makes minor adjustments to the project configuration file. The most significant changes focus on improving test coverage and enhancing the developer experience.

### Enhancements to testing:

* [`tests/test_server.py`](diffhunk://#diff-5620588ecb93aec064fe16ec7e5c10f6669041c927717e0f57b3f9a44ffec5acR1-R48): Added comprehensive unit tests for the MCP server, including tests for server initialization, tool registration, and ensuring the server's `run` method is called.

### Documentation updates:

* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R84-R91): Added a new section detailing how to run unit tests for the MCP server using the `unittest` framework.

### Minor project configuration adjustments:

* [`pyproject.toml`](diffhunk://#diff-50c86b7ed8ac2cf95bd48334961bf0530cdc77b5a56f852c5c61b89d735fd711R13): Added a blank line for improved readability in the dependencies section.